### PR TITLE
Update imdg and mc content sources and UI bundle

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -14,7 +14,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.5.1/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.6.2/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -14,7 +14,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.5.1/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.6.2/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/link-check-playbook.yml
+++ b/link-check-playbook.yml
@@ -7,25 +7,20 @@ content:
     branches: HEAD
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [master]
-    tags: [v*, "!v4.0*" , "!v3.12", "!v3.12.1", "!v3.12.2", "!v3.12.3",
-    "!v3.12.4", "!v3.12.5*", "!v3.12.6", "!v3.12.7", "!v3.12.8", "!v3.12.9",
-    "!v3.12.11", "!v3.11*", "!v3.10*", "!v3.9*", "!v3.8*", "!v3.7*", "!v3.6*",
-    "!v3.5*", "!v3.4*", "!v3.3*", "!v*-BETA*"]
+    branches: [master, v/*]
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [archive]
+    branches: [archived-versions]
     start_paths: docs/*
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [main]
-    tags: [v*]
+    branches: [main, v/*]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [archive]
+    branches: [archived-versions]
     start_paths: docs/*
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.5.1/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.6.2/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:


### PR DESCRIPTION
When we update the [release process](https://github.com/hazelcast/hazelcast-docs/pull/156), MC and IMDG content will be stored in branches rather than tags. This PR updates those sources to allow the link checker to work.