### PR TITLE
Docs 324 console link consistency and resources

### DIFF
--- a/docs/modules/ROOT/pages/backup-and-restore.adoc
+++ b/docs/modules/ROOT/pages/backup-and-restore.adoc
@@ -13,7 +13,7 @@ To back up or restore clusters in a team, you must have either an admin or devel
 
 == Creating a Backup
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Click *Create a backup*.
  
@@ -27,7 +27,7 @@ You can keep at most 10 backups. The oldest backup will be deleted automatically
 
 When you have at least one backup, you can use it to bootstrap a new cluster.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Click *Create a backup*.
 

--- a/docs/modules/ROOT/pages/connect-to-cluster.adoc
+++ b/docs/modules/ROOT/pages/connect-to-cluster.adoc
@@ -22,9 +22,9 @@ If you're using a {hazelcast-cloud} Dedicated cluster, you need to xref:authoriz
 
 Your cluster comes with a downloadable client that's preconfigured to connect to your cluster.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click *Connect Client*.
-. Select a client from the dropdown.
+. Select a client.
 . Follow the on-screen instructions.
 
 For a complete tutorial, see xref:get-started.adoc[].
@@ -41,7 +41,7 @@ include::partial$get-connection-creds.adoc[]
 
 In Management Center, you can open a SQL shell in your cluster and submit SQL queries directly from your web browser.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to *Management Center*.
 
@@ -57,15 +57,15 @@ xref:developer-guide.adoc[].
 
 - xref:hazelcast:clients:java.adoc#configuring-java-client[Java client]
 
-- link:https://github.com/hazelcast/hazelcast-nodejs-client#configuration[Node.js client]
+- link:https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md#3-configuration[Node.js client]
 
-- link:https://github.com/hazelcast/hazelcast-python-client#142-configuring-hazelcast-python-client[Python client]
+- link:https://hazelcast.readthedocs.io/en/stable/configuration_overview.html[Python client]
 
-- link:https://github.com/hazelcast/hazelcast-go-client#3-configuration-overview[Go client]
+- link:https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client#hdr-Configuration[Go client]
 
 - link:http://hazelcast.github.io/hazelcast-csharp-client/dev/doc/configuration.html[.NET client]
 
-- link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md[{cpp} client]
+- link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#142-configuring-hazelcast-c-client[{cpp} client]
 
 - link:https://github.com/hazelcast/hazelcast-packaging[CLI client]
 

--- a/docs/modules/ROOT/pages/create-account.adoc
+++ b/docs/modules/ROOT/pages/create-account.adoc
@@ -44,7 +44,7 @@ A confirmation email will be sent to your registered email address and you will 
 
 When you first sign into the Hazelcast {hazelcast-cloud} console, you are prompted to provide your company name and location. You can update these details at any time.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Profile*.
 . Enter your details and click *Update my details*.
@@ -53,7 +53,7 @@ When you first sign into the Hazelcast {hazelcast-cloud} console, you are prompt
 
 If you registered with an email address, you can change your account password:
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Password*.
 . Click *Reset*.

--- a/docs/modules/ROOT/pages/create-dedicated-cluster.adoc
+++ b/docs/modules/ROOT/pages/create-dedicated-cluster.adoc
@@ -23,7 +23,7 @@ If you give your cluster too few resources, your cluster may fail under heavy lo
 
 To request a {hazelcast-cloud} Dedicated cluster, do the following:
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Go to *Plans* > *Dedicated* in the left navigation.
 . Complete the form and click *Get in touch*.
 

--- a/docs/modules/ROOT/pages/create-serverless-cluster.adoc
+++ b/docs/modules/ROOT/pages/create-serverless-cluster.adoc
@@ -28,7 +28,7 @@ To create a development cluster, do the following:
 . Click *Create New Cluster*.
 . Click *Create Development Cluster*.
 . Update the cluster name if you want to. You cannot change the cluster name after the cluster is created.
-. Click *Create Cluster* 
+. Click *Create Cluster*. 
 . Wait while your cluster is created. When the cluster is up and running, a *Quick Connection Guide* is displayed with instructions for connecting a sample client to it.
 // end::development[]
 --

--- a/docs/modules/ROOT/pages/create-serverless-cluster.adoc
+++ b/docs/modules/ROOT/pages/create-serverless-cluster.adoc
@@ -24,17 +24,12 @@ Development cluster::
 To create a development cluster, do the following:
 
 // tag::development[]
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
-. Click *Plans* in the left navigation.
-. Click *Create cluster* in the *Serverless* tab.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
+. Click *Create New Cluster*.
 . Click *Create Development Cluster*.
-. Select a region.
-+
-TIP: For best performance, use a region that's closest to your client application or data stores. The closer your clients and data are to the cluster, the lower the network latency.
-
-. Give your cluster a memorable name. You cannot change your cluster name after it has been created.
-
-It takes a few minutes to create a {hazelcast-cloud} Serverless cluster. When the cluster state changes from *Pending* to *Running*, you can start using it.
+. Update the cluster name if you want to. You cannot change the cluster name after the cluster is created.
+. Click *Create Cluster* 
+. Wait while your cluster is created. When the cluster is up and running, a *Quick Connection Guide* is displayed with instructions for connecting a sample client to it.
 // end::development[]
 --
 
@@ -44,16 +39,13 @@ Production cluster::
 To create a production cluster, do the following:
 
 // tag::production[]
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
-. Click *Plans* in the left navigation.
-. Click *Create cluster* in the *Serverless* tab.
-. Click *Create Production Cluster*
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console, window=blank].
+. Click *Create New Cluster*.
+. Click *Create Production Cluster*.
+. Update the cluster name if you want to. You cannot change the cluster name after the cluster is created.
+. Click *Create Cluster*
 . Select a region.
-+
-TIP: For best performance, use a region that's closest to your client applications or data stores. The closer your clients and data are to the cluster, the lower the network latency.
-. Give your cluster a memorable name. You cannot change your cluster name after it has been created.
-
-It takes a few minutes to create a {hazelcast-cloud} Serverless cluster. When the cluster state changes from *Pending* to *Running*, you can start using it.
+. Wait while your cluster is created. When the cluster is up and running, a *Quick Connection Guide* is displayed with instructions for connecting a sample client to it.
 // end::production[]
 --
 ====

--- a/docs/modules/ROOT/pages/custom-classes-upload.adoc
+++ b/docs/modules/ROOT/pages/custom-classes-upload.adoc
@@ -38,7 +38,7 @@ You must have either an xref:teams-and-users.adoc[admin or developer role] to up
 
 . Use your build tool such as Gradle or Maven to package the classes into a JAR or ZIP file.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to *Manage* > *Custom Classes* and use the file selector to upload the file to Hazelcast {hazelcast-cloud}.
 
@@ -48,7 +48,7 @@ When the file is uploaded and ready to use, you will see a success message.
 
 To remove cluster-side modules from the cluster, you must use the Hazelcast {hazelcast-cloud} console.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to *Manage* > *Custom Classes* and find your class in the list.
 
@@ -58,6 +58,6 @@ To remove cluster-side modules from the cluster, you must use the Hazelcast {haz
 
 To download a cluster-side module, you must use the Hazelcast {hazelcast-cloud} console.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 
 . Go to *Manage* > *Custom Classes*, find your class in the *Uploaded Classes* list and click on it.

--- a/docs/modules/ROOT/pages/deleting-a-cluster.adoc
+++ b/docs/modules/ROOT/pages/deleting-a-cluster.adoc
@@ -12,7 +12,7 @@ You cannot delete a cluster that is using WAN Replication.
 
 == Using the Hazelcast {hazelcast-cloud} Console
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Click *Delete* and confirm your choice.
 

--- a/docs/modules/ROOT/pages/developer.adoc
+++ b/docs/modules/ROOT/pages/developer.adoc
@@ -13,7 +13,7 @@ To manage API keys for a team's cluster, you must have either an xref:create-acc
 // tag::create[]
 To create a new set of API credentials, do the following:
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Developer*.
 . Click *Generate new API Key*.

--- a/docs/modules/ROOT/pages/download-logs.adoc
+++ b/docs/modules/ROOT/pages/download-logs.adoc
@@ -4,7 +4,7 @@
 
 {description}
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Click *Download Logs* to download a ZIP file that contains all logs of members in your cluster.
 

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -35,7 +35,7 @@ Java::
 Before you begin:
 
 * Install Java 8-17 and set the `JAVA_HOME` environment variable to the location of your JRE.
-* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-6, step 6>>.
 
 []
 . In the *Quick Connection Guide* on your cluster, click on the Java icon and then click *Download*.
@@ -54,16 +54,14 @@ Before you begin:
 .. If you use Windows, execute: 
 +
 ```bash
-./mvnw.cmd clean compile exec:java@client-with-ssl
+mvnw.cmd clean compile exec:java@client-with-ssl
 ```
 +
 When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-To query data in the `cities` map, you need to create a mapping to it.
+. To query data in the `cities` map, you need to create a mapping to it. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
 
-. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
-
-. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+. [[step-6]]In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
 
 . Paste the following command into the SQL Browser and execute it.
 
@@ -71,7 +69,7 @@ To query data in the `cities` map, you need to create a mapping to it.
 [source,sql]
 ----
 CREATE OR REPLACE MAPPING cities (
-__key INT,
+__key VARCHAR,
 country VARCHAR, 
 city VARCHAR,
 population INT)
@@ -90,7 +88,7 @@ Node.js::
 Before you begin:
 
 * link:https://nodejs.org/en/download/[Install Node.js 10 or newer].
-* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-6n, step 6>>.
 
 []
 . In the *Quick Connection Guide*, click on the NodeJS icon and then click *Download*.
@@ -107,18 +105,16 @@ npm run client_with_ssl
 +
 When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-To query data in the `cities` map, you need to create a mapping to it.
+. To query data in the `cities` map, you need to create a mapping to it. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
 
-. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
-
-. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+. [[step-6n]]In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
 
 . Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
 CREATE OR REPLACE MAPPING cities (
-__key INT,
+__key VARCHAR,
 country VARCHAR, 
 city VARCHAR,
 population INT)
@@ -137,7 +133,7 @@ Python::
 Before you begin:
 
 * link:https://www.python.org/downloads/[Install Python 3.6 or newer].
-* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-6py, step 6>>.
 
 []
 . In the *Quick Connection Guide*, click on the Python icon and then click *Download*.
@@ -158,14 +154,14 @@ To query data in the `cities` map, you need to create a mapping to it.
 
 . In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
 
-. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+. [[step-6py]]In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
 
 . Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
 CREATE OR REPLACE MAPPING cities (
-__key INT,
+__key VARCHAR,
 country VARCHAR, 
 city VARCHAR,
 population INT)
@@ -182,8 +178,8 @@ TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/ha
 --
 Before you begin:
 
-* link:https://dotnet.microsoft.com/en-us/download/dotnet/3.1[Install .NET].
-* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+* link:https://dotnet.microsoft.com/en-us/download/dotnet/6.0[Install .NET].
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-6net, step 6>>.
 
 []
 . In the *Quick Connection Guide*, click on the .NET icon and then click *Download*.
@@ -204,14 +200,14 @@ To query data in the `cities` map, you need to create a mapping to it.
 
 . In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
 
-. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+. [[step-6net]]In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
 
 . Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
 CREATE OR REPLACE MAPPING cities (
-__key INT,
+__key VARCHAR,
 country VARCHAR, 
 city VARCHAR,
 population INT)
@@ -229,7 +225,7 @@ C++::
 Before you begin:
 
 * link:https://vcpkg.io/en/getting-started.html[Install vcpkg].
-* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-6cpp, step 6>>.
 
 []
 . In the *Quick Connection Guide*, click on the C++ icon and then click *Download*.
@@ -268,7 +264,7 @@ To query data in the `cities` map, you need to create a mapping to it.
 
 . In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
 
-. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+. [[step-6cpp]]In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
 
 . Paste the following command into the SQL Browser and execute it.
 +
@@ -293,7 +289,7 @@ Go::
 Before you begin:
 
 * link:https://go.dev/doc/install[Install Go].
-* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-6go, step 6>>.
 
 []
 . In the *Quick Connection Guide*, click on the C++ icon and then click *Download*.
@@ -314,14 +310,14 @@ To query data in the `cities` map, you need to create a mapping to it.
 
 . In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
 
-. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+. [[step-6go]]In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
 
 . Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
 CREATE OR REPLACE MAPPING cities (
-__key INT,
+__key VARCHAR,
 country VARCHAR, 
 city VARCHAR,
 population INT)
@@ -336,7 +332,7 @@ TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/ha
 SQL (CLI):: 
 + 
 --
-If you've followed the onscreen *Quick Connection Guide*, jump straight to step 7.
+If you've followed the onscreen *Quick Connection Guide*, jump straight to <<step-7, step 7>>.
 
 []
 . Install the Hazelcast CLI client for your operating system.
@@ -382,7 +378,7 @@ You should see your installed version of the CLI client.
 
 . From a command prompt, change into the root directory where you extracted the ZIP file.
 
-. Execute the following command to connect to the SQL shell to your cluster.
+. Execute the following command to connect to the SQL shell to your cluster. You may need add a path to the hz-cli program.
 +
 ```bash
 hz-cli -f hazelcast-client-with-ssl.yml sql
@@ -396,7 +392,7 @@ sql>
 +
 The Hazelcast CLI client is successfully connected to your Serverless cluster.
 
-. Create a mapping to a new map called `cities`.
+. [[step-7]]Create a mapping to a new map called `cities`.
 +
 [source,sql]
 ----
@@ -431,7 +427,7 @@ INSERT INTO cities VALUES
 
 Now that you have some data in your cluster, you can query it, using SQL. If you're using the CLI, enter the following  queries in the SQL prompt. If you're using a client library, enter the following queries in the SQL Browser.
 
-. Use the `SELECT` statement to query all data in the map.
+. Execute the following `SELECT` statement to query all data in the map.
 +
 [source,sql]
 ----

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -21,7 +21,7 @@ To create a development cluster, do the following:
 
 include::create-serverless-cluster.adoc[tag=development] 
 
-== Step 2. Run a Sample Client
+== Step 2. Connect a Sample Client
 
 To connect to your {hazelcast-cloud} Serverless cluster, you need a Hazelcast client. The cluster comes with sample clients that are preconfigured to connect to your cluster and add some sample data to a map. A map is an in-memory, key/value data structure that is often used as a cache.
 
@@ -32,34 +32,41 @@ Choose a client and follow the instructions.
 Java:: 
 + 
 --
-. Make sure that you have Java 8-17 installed and the `JAVA_HOME` environment variable is set to the location of your JRE.
+Before you begin:
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+* Install Java 8-17 and set the `JAVA_HOME` environment variable to the location of your JRE.
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
 
-. Click *Connect Client*.
+[]
+. In the *Quick Connection Guide* on your cluster, click on the Java icon and then click *Download*.
 
-. Go to the *Java* tab and download the ZIP file.
+. Extract the ZIP file.
 
-. Extract the ZIP file and change into the extracted directory.
+. From a command prompt, change into the root directory of the extracted files.
 
-. Execute the application from your command prompt:
-+
-When you see `Connection Successful!` in the output, the application is finished.
+. Execute one of the following commands to run your client:
 
-.. Execute the following if you use Linux or Mac: 
+.. If you use Linux or Mac, execute: 
 + 
 ```bash
 ./mvnw clean compile exec:java@client-with-ssl
 ```
-.. Execute the following if you use Windows: 
+.. If you use Windows, execute: 
 +
 ```bash
-mvnw.cmd clean compile exec:java@client-with-ssl
+./mvnw.cmd clean compile exec:java@client-with-ssl
 ```
++
+When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-. In the Hazelcast {hazelcast-cloud} console, go to *Management Center* and click *SQL Browser* in the top toolbar.
+To query data in the `cities` map, you need to create a mapping to it.
 
-. Enter the following in the SQL Browser to create a mapping to the `cities` map. The sample client that you just executed created this map for you and filled it with data.
+. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
+
+. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+
+. Paste the following command into the SQL Browser and execute it.
+
 +
 [source,sql]
 ----
@@ -80,21 +87,33 @@ TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/ha
 Node.js:: 
 + 
 --
-. link:https://nodejs.org/en/download/[Install Node.js 10 or newer].
+Before you begin:
 
-. Go to the *Node.js* tab and download the ZIP file.
+* link:https://nodejs.org/en/download/[Install Node.js 10 or newer].
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
 
-. Extract the ZIP file, change into the extracted root directory and execute the following command:
+[]
+. In the *Quick Connection Guide*, click on the NodeJS icon and then click *Download*.
+
+. Extract the ZIP file.
+
+. From a command prompt, change into the root directory of the extracted files.
+
+. Execute the following command to run your client:
 +
 ```bash
 npm run client_with_ssl
 ```
 +
-When you see `Connection Successful!` in the output, the application is finished.
+When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-. In the Hazelcast {hazelcast-cloud} console, go to *Management Center* and click *SQL Browser* in the top toolbar.
+To query data in the `cities` map, you need to create a mapping to it.
 
-. Enter the following in the SQL Browser to create a mapping to the `cities` map. The sample client that you just executed created this map for you and filled it with data.
+. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
+
+. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+
+. Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
@@ -115,21 +134,33 @@ TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/ha
 Python:: 
 + 
 --
-. link:https://www.python.org/downloads/[Install Python 3.6 or newer].
+Before you begin:
 
-. Go to the *Python* tab and download the ZIP file.
+* link:https://www.python.org/downloads/[Install Python 3.6 or newer].
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
 
-. Extract the ZIP file, change into the extracted root directory and execute the following command:
+[]
+. In the *Quick Connection Guide*, click on the Python icon and then click *Download*.
+
+. Extract the ZIP file.
+
+. From a command prompt, change into the root directory of the extracted files.
+
+. Execute the following command to run your client:
 +
 ```bash
 python3 -m pip install -r requirements.txt && python client_with_ssl.py
 ```
 +
-When you see `Connection Successful!` in the output, the application is finished.
+When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-. In the Hazelcast {hazelcast-cloud} console, go to *Management Center* and click *SQL Browser* in the top toolbar.
+To query data in the `cities` map, you need to create a mapping to it.
 
-. Enter the following in the SQL Browser to create a mapping to the `cities` map. The sample client that you just executed created this map for you and filled it with data.
+. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
+
+. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+
+. Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
@@ -149,21 +180,33 @@ TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/ha
 .NET:: 
 + 
 --
-. link:https://dotnet.microsoft.com/en-us/download/dotnet/3.1[Install .NET].
+Before you begin:
 
-. Go to the *.Net* tab and download the ZIP file.
+* link:https://dotnet.microsoft.com/en-us/download/dotnet/3.1[Install .NET].
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
 
-. Extract the ZIP file, change into the extracted directory and execute the following command:
+[]
+. In the *Quick Connection Guide*, click on the .NET icon and then click *Download*.
+
+. Extract the ZIP file.
+
+. From a command prompt, change into the root directory of the extracted files.
+
+. Execute the following command to run your client:
 +
 ```bash
 dotnet run --project ClientWithSsl
 ```
 +
-When you see `Connection Successful!` in the output, the application is finished.
+When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-. In the Hazelcast {hazelcast-cloud} console, go to *Management Center* and click *SQL Browser* in the top toolbar.
+To query data in the `cities` map, you need to create a mapping to it.
 
-. Enter the following in the SQL Browser to create a mapping to the `cities` map. The sample client that you just executed created this map for you and filled it with data.
+. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
+
+. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+
+. Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
@@ -180,24 +223,100 @@ type IMap OPTIONS('keyFormat'='varchar', 'valueFormat'='json-flat');
 TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/hazelcast-cloud-csharp-sample-client/blob/5.1/ClientWithSsl/Program.cs[`program.cs`] file to understand how the client connected. The client comes with some other examples that are commented out. To try those examples, you can uncomment them and run the application again.
 --
 
+C++:: 
++ 
+--
+Before you begin:
+
+* link:https://vcpkg.io/en/getting-started.html[Install vcpkg].
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
+
+[]
+. In the *Quick Connection Guide*, click on the C++ icon and then click *Download*.
+
+. Extract the ZIP file.
+
+. From a command prompt, change into the root directory of the extracted files.
+
+. Execute one of the following commands to run your client:
+
+.. If you use Linux or Mac, execute:
++
+```bash
+vcpkg install "hazelcast-cpp-client[openssl]" && 
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake && 
+cmake --build build &&
+./build/client_with_ssl
+```
+
+.. If you use Windows:
++ 
+```bash
+vcpkg install "hazelcast-cpp-client[openssl]" && 
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake && 
+cmake --build build &&
+./build/client_with_ssl
+```
++
+If the link:https://wiki.osdev.org/Target_Triplet[target triplet] doesn't match your operating system, you may need to provide a target suffix to the `install` command. For example: `vcpkg install "hazelcast-cpp-client[openssl]:x64-windows"`
++
+The location of the compiled binary may change according to configuration and system defaults.
++
+When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
+
+To query data in the `cities` map, you need to create a mapping to it.
+
+. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
+
+. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+
+. Paste the following command into the SQL Browser and execute it.
++
+[source,sql]
+----
+CREATE OR REPLACE MAPPING cities (
+__key VARCHAR,
+country VARCHAR, 
+city VARCHAR,
+population INT)
+type IMap OPTIONS('keyFormat'='varchar', 'valueFormat'='json-flat');
+----
+
+. Continue to the <<step-3, next step>> to query your sample data in the SQL browser.
+
+TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/hazelcast-cloud-cpp-sample-client/blob/5.1/client_with_ssl.cpp[`client_with_ssl.cpp`] file to understand how the client connected. The client comes with some other examples that are commented out. To try those examples, you can uncomment them and run the application again.
+--
+
 Go:: 
 + 
 --
-. link:https://go.dev/doc/install[Install Go].
+Before you begin:
 
-. Go to the *Go* tab and download the ZIP file.
+* link:https://go.dev/doc/install[Install Go].
+* If you've followed the onscreen *Quick Connection Guide*, jump straight to step 6.
 
-. Extract the ZIP file, change into the extracted directory and execute the following command:
+[]
+. In the *Quick Connection Guide*, click on the C++ icon and then click *Download*.
+
+. Extract the ZIP file.
+
+. From a command prompt, change into the root directory of the extracted files.
+
+. Execute the following commands to run your client:
 +
 ```bash
 go mod tidy && go run client_with_ssl.go
 ```
 +
-When you see `Connection Successful!` in the output, the application is finished.
+When you see `Connection Successful!` in the output, the client is successfully connected to your Serverless cluster and populates a `cities` map with data.
 
-. In the Hazelcast {hazelcast-cloud} console, go to *Management Center* and click *SQL Browser* in the top toolbar.
+To query data in the `cities` map, you need to create a mapping to it.
 
-. Enter the following in the SQL Browser to create a mapping to the `cities` map. The sample client that you just executed created this map for you and filled it with data.
+. In step 3 of the *Quick Connection Guide* on your cluster, click *Dashboard*.
+
+. In *Cluster Details*, click *Management Center*, and then from the top toolbar click *SQL Browser*.
+
+. Paste the following command into the SQL Browser and execute it.
 +
 [source,sql]
 ----
@@ -214,62 +333,13 @@ type IMap OPTIONS('keyFormat'='varchar', 'valueFormat'='json-flat');
 TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/hazelcast-cloud-go-sample-client/blob/5.1/client_with_ssl.go[`client_with_ssl.go`] file to understand how the client connected. The client comes with some other examples that are commented out. To try those examples, you can uncomment them and run the application again.
 --
 
-C++:: 
-+ 
---
-. link:https://vcpkg.io/en/getting-started.html[Install vcpkg].
-. Go to the *{cpp}* tab and download the ZIP file.
-
-. Extract the ZIP file, change into the extracted directory, and execute the program:
-+
-When you see `Connection Successful!` in the output, the application is finished.
-
-.. Execute the following if you use Linux or Mac:
-+
-```bash
-vcpkg install "hazelcast-cpp-client[openssl]" && 
-cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake && 
-cmake --build build &&
-./build/client_with_ssl
-```
-
-.. Execute the following if you use Windows:
-+ 
-```bash
-vcpkg install "hazelcast-cpp-client[openssl]" && 
-cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake && 
-cmake --build build &&
-./build/client_with_ssl
-```
-+
-If the link:https://wiki.osdev.org/Target_Triplet[target triplet] doesn't match your operating system, you may need to provide a target suffix to the `install` command. For example: `vcpkg install "hazelcast-cpp-client[openssl]:x64-windows"`
-+
-The location of the compiled binary may change according to configuration and system defaults.
-
-
-. In the Hazelcast {hazelcast-cloud} console, go to *Management Center* and click *SQL Browser* in the top toolbar.
-
-. Enter the following in the SQL Browser to create a mapping to the `cities` map. The sample client that you just executed created this map for you and filled it with data.
-+
-[source,sql]
-----
-CREATE OR REPLACE MAPPING cities (
-__key INT,
-country VARCHAR, 
-city VARCHAR,
-population INT)
-type IMap OPTIONS('keyFormat'='varchar', 'valueFormat'='json-flat');
-----
-
-. Continue to the <<step-3, next step>> to query your sample data in the SQL browser.
-
-TIP: Take a moment, to read the code in the link:https://github.com/hazelcast/hazelcast-cloud-cpp-sample-client/blob/5.1/client_with_ssl.cpp[`client_with_ssl.cpp`] file to understand how the client connected. The client comes with some other examples that are commented out. To try those examples, you can uncomment them and run the application again.
---
-
 SQL (CLI):: 
 + 
 --
-. Install the Hazelcast CLI client. Use one of the following methods, depending on your operating system.
+If you've followed the onscreen *Quick Connection Guide*, jump straight to step 7.
+
+[]
+. Install the Hazelcast CLI client for your operating system.
 +
 .Mac
 [source,bash]
@@ -306,29 +376,25 @@ hz-cli -V
 +
 You should see your installed version of the CLI client.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. In the *Quick Connection Guide*, click the SQL icon and then click *Download*.
 
-. Click *Connect Client*.
+. Extract the ZIP file which contains credentials that allow the Hazelcast CLI to connect to your cluster.
 
-. Go to the *SQL* tab and download the ZIP file.
+. From a command prompt, change into the root directory where you extracted the ZIP file.
 
-. Extract the ZIP file.
-+
-This file contains the credentials that allow the CLI to connect to your cluster.
-
-. Change into the directory where you extracted the ZIP file.
-
-. Connect to the SQL shell on your cluster.
+. Execute the following command to connect to the SQL shell to your cluster.
 +
 ```bash
 hz-cli -f hazelcast-client-with-ssl.yml sql
 ```
 +
-You should see the SQL prompt:
+A SQL prompt is displayed:
 +
 ```
 sql>
 ```
++
+The Hazelcast CLI client is successfully connected to your Serverless cluster.
 
 . Create a mapping to a new map called `cities`.
 +
@@ -356,6 +422,7 @@ INSERT INTO cities VALUES
 (7, 'Brazil', 'Sao Paulo', 22429800),
 (8, 'Brazil', 'Rio de Janeiro', 13634274);
 ----
+. Continue to the <<step-3, next step>> to query your sample data in the SQL browser.
 --
 ====
 
@@ -523,15 +590,15 @@ Learn more about using clients:
 
 - xref:hazelcast:clients:java.adoc#configuring-java-client[Java client]
 
-- link:https://github.com/hazelcast/hazelcast-nodejs-client#configuration[Node.js client]
+- link:https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md#3-configuration[Node.js client]
 
-- link:https://github.com/hazelcast/hazelcast-python-client#142-configuring-hazelcast-python-client[Python client]
+- link:https://hazelcast.readthedocs.io/en/stable/configuration_overview.html[Python client]
 
-- link:https://github.com/hazelcast/hazelcast-go-client#3-configuration-overview[Go client]
+- link:https://pkg.go.dev/github.com/hazelcast/hazelcast-go-client#hdr-Configuration[Go client]
 
 - link:http://hazelcast.github.io/hazelcast-csharp-client/dev/doc/configuration.html[.NET client]
 
-- link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md[{cpp} client]
+- link:https://github.com/hazelcast/hazelcast-cpp-client/blob/v4.1.0/Reference_Manual.md#142-configuring-hazelcast-c-client[{cpp} client]
 
 - link:https://github.com/hazelcast/hazelcast-packaging[CLI client]
 

--- a/docs/modules/ROOT/pages/hazelcast-version.adoc
+++ b/docs/modules/ROOT/pages/hazelcast-version.adoc
@@ -6,7 +6,7 @@
 
 To update the version of a team's cluster, you must have either an xref:teams-and-users.adoc[admin or developer role].
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Go to *Manage* > *Hazelcast Version*.
 . Select a new version from the dropdown.
 . Click *Update*.

--- a/docs/modules/ROOT/pages/ip-white-list.adoc
+++ b/docs/modules/ROOT/pages/ip-white-list.adoc
@@ -7,7 +7,7 @@
 
 To add IP addresses to the whitelist of a team's cluster, you must have either an xref:teams-and-users.adoc[admin or developer role].
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Click *IP Whitelisting*.
 

--- a/docs/modules/ROOT/pages/logging-integration.adoc
+++ b/docs/modules/ROOT/pages/logging-integration.adoc
@@ -19,7 +19,7 @@ You need the following:
 
 To set up logging integration, do the following:
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to  *Manage* > *Logging*.
 

--- a/docs/modules/ROOT/pages/management-center.adoc
+++ b/docs/modules/ROOT/pages/management-center.adoc
@@ -9,7 +9,7 @@ Management Center is enabled for {hazelcast-cloud} Serverless clusters, but disa
 
 To open Management Center, do the following:
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to *Management Center*.
 
@@ -18,7 +18,7 @@ To open Management Center, do the following:
 
 To use Management Center in a {hazelcast-cloud} Dedicated cluster, you need to enable it.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud,window=_blank} console,window=_blank] and select your cluster.
 
 . Go to *Management Center* and select *Enable*.
 
@@ -34,7 +34,7 @@ If your IP address is included in the whitelist, you should see a read-only view
 
 == Disabling Management Center for {hazelcast-cloud} Dedicated Clusters
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Go to *Management Center* > *Configure Access* and uncheck the checkbox.
 
 == Related Resources

--- a/docs/modules/ROOT/pages/maploader-and-mapstore.adoc
+++ b/docs/modules/ROOT/pages/maploader-and-mapstore.adoc
@@ -47,7 +47,7 @@ Before you can configure the MapStore, you need to deploy it by packaging your c
 
 To use a MapStore, it must be configured for a specific map in Hazelcast {hazelcast-cloud}. When a map is configured with a MapStore, Hazelcast plugs the MapStore implementation into the lifecycle of the map so that the MapStore is triggered when certain map operations are invoked.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Go to *Data Structure Config* > *Add New Configuration*.
 . Configure the map.
 . In the bottom left corner, select *Enable MapStore*.

--- a/docs/modules/ROOT/pages/multi-factor-authentication.adoc
+++ b/docs/modules/ROOT/pages/multi-factor-authentication.adoc
@@ -9,7 +9,7 @@
 == Enabling Multi-Factor Authentication
 
 . Install an authenticator app such as Google Authenticator on your device.
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Security*.
 . Open your authenticator app and scan the QR code that is displayed in the Hazelcast {hazelcast-cloud} console. 
@@ -25,7 +25,7 @@ Verification codes are specific to a particular device and cannot be transferred
 
 If you've enabled MFA, you can disable it so that you can sign in without an authenticator app.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Security*.
 . Click *Disable*.

--- a/docs/modules/ROOT/pages/payment-methods.adoc
+++ b/docs/modules/ROOT/pages/payment-methods.adoc
@@ -20,7 +20,7 @@ To set up automatic payments for your usage, add a payment card to your account.
 
 NOTE: Hazelcast uses a third-party to store payment details and process payments. Payment details are not stored in Hazelcast.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Billing & Payments*.
 . Click *Add Payment Method*.
@@ -30,7 +30,7 @@ You can add only one payment card to your account. To change the payment card, u
 
 == Updating a Payment Card
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Billing & Payments*.
 . Click *Update Payment Method*.
@@ -48,7 +48,7 @@ To remove a payment card from your account, contact us at mailto:support@hazelca
 
 You can see how much you've spent in the current month as well as previous invoices.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 . Click the *Account* icon in the bottom left corner.
 . Click *Billing & Payments*.
 

--- a/docs/modules/ROOT/pages/scale-up-down.adoc
+++ b/docs/modules/ROOT/pages/scale-up-down.adoc
@@ -18,7 +18,7 @@ Scaling a cluster may take up to 8 or 10 minutes.
 
 When data in a cluster occupies 80% of all available memory, we send a warning email to the account or team owner. At this point, we recommend scaling out the cluster, which adds more members and therefore more resources such as memory. When you scale out a cluster, client applications do not experience any downtime. However, the cluster may temporarily experience lower throughput while members migrate their partitions.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Go to *Manage* > *Scale Up/Down*.
 +
 - *Instance Count Per Zone*: Number of members you have in each availability zone. 
@@ -35,7 +35,7 @@ If you're using fewer resources than you thought you would when you created the 
 
 WARNING: If you scale in to a size that's smaller than your actual data size, some of your data will be removed.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Go to *Manage* > *Scale Up/Down*.
 +
 - *Instance Count Per Zone*: Number of members you have in each availability zone. 

--- a/docs/modules/ROOT/pages/stop-and-resume.adoc
+++ b/docs/modules/ROOT/pages/stop-and-resume.adoc
@@ -15,7 +15,7 @@ You cannot pause a {hazelcast-cloud} Dedicated cluster if it's hosted on Google 
 
 Pausing your cluster can help minimize your costs because you are charged only for running clusters.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Click *Pause*.
 
 If you're using a {hazelcast-cloud} Serverless production cluster, Hazelcast saves your cluster data so that you can resume the cluster at a later time.
@@ -30,5 +30,5 @@ If you're using a {hazelcast-cloud} Serverless development cluster, all cluster 
 
 == Resuming a Cluster
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 . Click *Resume*.

--- a/docs/modules/ROOT/pages/teams-and-users.adoc
+++ b/docs/modules/ROOT/pages/teams-and-users.adoc
@@ -10,7 +10,7 @@ NOTE: {hazelcast-cloud} Serverless clusters for teams do not include the free 2 
 
 == Creating a Team
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 
 . Click the *Account* icon in the bottom left corner.
 
@@ -24,7 +24,7 @@ Now that you've created a team, you can invite users to it and assign them roles
 
 If you've created one or more teams, you can invite users to them and assign those users a role.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console].
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank].
 
 . Click the *Account* icon in the bottom left corner.
 

--- a/docs/modules/ROOT/pages/wan-replication.adoc
+++ b/docs/modules/ROOT/pages/wan-replication.adoc
@@ -46,7 +46,7 @@ contains xref:cluster-side-modules.adoc[cluster-side modules] or persistence, th
 
 Set up WAN Replication between two clusters.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select the cluster that you want to use as a publisher cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select the cluster that you want to use as a publisher cluster.
 
 +
 NOTE: If you want to set up a pair of clusters in an Active-Active configuration, select either cluster.

--- a/docs/modules/ROOT/partials/get-connection-creds.adoc
+++ b/docs/modules/ROOT/partials/get-connection-creds.adoc
@@ -1,6 +1,6 @@
 To connect your own client to the cluster, you need your cluster's connection credentials.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to *Connect Client* > *Advanced setup*:
 +

--- a/tutorials/modules/ROOT/pages/create-materialized-view-from-kafka.adoc
+++ b/tutorials/modules/ROOT/pages/create-materialized-view-from-kafka.adoc
@@ -54,7 +54,7 @@ image:confluent-cloud-breadcrumbs.png[Breadcrumbs that display the cluster name]
 
 To allow Hazelcast to access the `trades` topic that you created in your Confluent Cloud Kafka cluster, you need to create a mapping to it.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select your cluster.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select your cluster.
 
 . Go to *Management Center* > *SQL Browser*.
 

--- a/tutorials/modules/ROOT/pages/integrate-logs-with-amazon-elasticsearch-service.adoc
+++ b/tutorials/modules/ROOT/pages/integrate-logs-with-amazon-elasticsearch-service.adoc
@@ -63,7 +63,7 @@ Configure your {hazelcast-cloud} Dedicated cluster to send log files to the Open
 
 You'll need the master user credentials and domain endpoint that you created when you <<configure-opensearch-domain, configured OpenSearch>>.
 
-. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] and select the cluster that want to integrate with OpenSearch.
+. Sign into the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console,window=_blank] and select the cluster that want to integrate with OpenSearch.
 . Select *Manage* > *Logging*.
 . From the *Logging Technology* list, select *Elastic Stack (ELK)*.
 . In the *Username* and *Password* fields, enter your master user credentials.


### PR DESCRIPTION
Includes the following:

* Links to console open in a new tab
* Correct links to individual client docs
* Consistency of instructions for running sample clients in Hello World tutorial. Now reflect the flow of the onscreen instructions.
* Updates to mapping statements. NOTE: It looks like SQL(CLI) writes data to cluster in different format from the other clients, so the mapping statements need to be different. 
