### PR TITLE
DOCS-347 Billing examples and charging clarification

### DIFF
--- a/docs/modules/ROOT/pages/serverless-cluster.adoc
+++ b/docs/modules/ROOT/pages/serverless-cluster.adoc
@@ -41,7 +41,7 @@ Development clusters have the following limitations:
 - No data backups
 - No cluster data persistence
 
-When a development cluster restarts for any reason, you lose cluster data such as maps and cluster-side modules.
+When a development cluster restarts for any reason, you lose cluster data, such as maps and cluster-side modules.
 
 NOTE: You cannot convert a development cluster to a production cluster.
 
@@ -49,28 +49,32 @@ NOTE: You cannot convert a development cluster to a production cluster.
 == Production Clusters
 
 // tag::production[]
-Production clusters are for applications that have already been tested and are ready to be deployed in real-world scenarios.
+Production clusters are for applications that have already been tested and are ready for deployment in real-world scenarios.
 // end::production[]
 
-Production clusters automatically scale out and in, depending on the amount of resources you use.
+Production clusters automatically scale out and in, depending on the amount of resources that you use.
 
-Your cluster data is persisted on disk so that you can pause and resume your clusters when you want, without losing your data. Cluster data is persisted in the following scenarios:
+=== Backups to Disk
 
-- Automatic backups once per day.
-- When a production cluster restarts for any reason.
-- You trigger manual backups.
+Backup copies of your cluster data are stored on disk so that you can pause and resume your clusters when you want, without losing data. Cluster data consists of the following:
 
-.What is cluster data?
-[%collapsible]
-====
-include::partial$cluster-data.adoc[]
-====
+- Configuration settings
+- Cluster-side modules
+- Jobs
+- Map and JCache data structures
 
-=== Backups
+Production clusters use the following backups:
 
-By default, data in production clusters is backed up on one other member in the cluster.
+- *Automatic backups:* A full backup of your cluster data is copied to disk once every 24 hours, and when a cluster is paused.
+- *Manual backups:* You can take a xref:backup-and-restore.adoc[manual backup] of your cluster data at any time. Take up to a maximum of ten backups.
 
-Although you can configure some xref:data-structures.adoc[data structures] with a custom backup count, the effective backup count is limited by the number of members in your cluster. For example, if you configure a map with 5 backups, but your cluster has only 2 members, you will have one effective backup. You cannot scale out {hazelcast-cloud} Serverless clusters. If you add enough data to the cluster so that it automatically scales up the number of members, more backups will be added, up to your configured count of 5.
+=== Backups to Other Members
+
+By default, data on production clusters is backed up on one other member in the cluster.
+
+Although you can configure some xref:data-structures.adoc[data structures] with a custom backup count, the effective backup count is limited by the number of members in your cluster. 
+
+For example, if you configure a map with five backups, but your cluster has only two members, you will have one effective backup. You need to add enough data to the cluster so that it automatically scales up the number of members and backups to your configured count of five. 
 
 == Restrictions on Free {hazelcast-cloud} Serverless Clusters
 
@@ -85,11 +89,13 @@ If you're using a development cluster, all cluster data is lost after the cluste
 
 == Pricing for {hazelcast-cloud} Serverless Clusters
 
-You pay only for what you store in RAM. Any data that is stored on disk or in backups is free of charge. As a result, 'storage' is synonymous with RAM in {hazelcast-cloud} Serverless clusters.
+You pay only for what you store in RAM. Any data that is stored on disk or in backups to disk is free of charge. As a result, 'storage' is synonymous with RAM in {hazelcast-cloud} Serverless clusters.
 
-{hazelcast-cloud} Serverless clusters are billed monthly only for the amount of used storage. The *first 2 GiB of storage in your account is free*. If you use more than 2 GiB across all your clusters, you are charged $0.10 per hour for every additional GiB of used storage, not including the first 2 GiB.
+{hazelcast-cloud} Serverless clusters are billed monthly only for the amount of storage that you use. The *first 2 GiB of storage in your account is free*. If you use more than 2 GiB across all your clusters, you are charged $0.10 per hour for every additional GiB of used storage, not including the first 2 GiB.
 
-As well as the data that you add to data structures such as maps, you are charged for any additional memory usage, excluding backups. *Backups are free*. Additional memory usage may include the following:
+As well as the data that you add to data structures, such as maps, you are charged if you configure more than one backup of a data structure. Only the first backup is free.
+
+Additional memory usage is also charged for, and may include the following:
 
 - Indexes that you create
 - Stateful jobs
@@ -99,25 +105,72 @@ For example, the xref:cluster-side-modules.adoc#serializers[`HazelcastJsonValue`
 
 === Billing Examples
 
-You have an empty cluster. You ingest 3 GiB of data into the cluster, run a query, and remove the data. For one hour, your cluster stored 3 GiB data, and then the cluster remained empty for the rest of the month. You are billed for 1 GiB for one hour, which is $0.10.
+The following examples show the cost of using different resources.
 
-These examples show the cost per month of two clusters in the same account:
+==== Scenario 1: Data Only
 
-[cols="a,a,a,a"]
+You have an empty cluster. You create a map on the cluster, using the default configuration. You then ingest 3 GiB of data into the cluster, run a query, and remove the data. 
+
+For one hour, your cluster stored 3 GiB data, and then the cluster remained empty for the rest of the month.
+
+[cols="a,a,a"]
 |===
-|Cluster|Used storage|Time|Cost
+|Total Storage|Time|Cost
 
-|1
-|2 GiB
-|Unlimited
-|Free
-
-|2
-|10 GiB
-|10 minutes
-|10 GiB * 10/60 * 0.1 = $0.16
+|3 GiB (data) - 2 GiB (free) = 1 GiB
+|1 hour
+|$0.10
 
 |===
+
+==== Scenario 2: Data and Cluster Backup to Disk
+
+You have two empty clusters managed from the same account. You create maps on both clusters, using the default configuration. You then ingest 3 GiB of data into each cluster. You run the same query on the two clusters, take manual backups, and remove the data from both.
+
+For one hour, each of your clusters stored 3 GiB of data.
+
+
+[frame=sides,grid=cols,cols="a,a,a,a"]
+|===
+|Storage Per Cluster|Total Storage|Time|Cost
+
+|*Cluster 1:* 3 GiB (data)
+.2+<.^|6 GiB (data) - 2 GiB (free) = 4 GiB
+.2+<.^|1 hour
+.2+<.^|$0.40
+
+|*Cluster 2:* 3 GiB (data)
+|
+|
+| 
+
+|===
+
+NOTE: The 3 GiB manual backup of each cluster is saved to disk and so is free of charge.
+
+==== Scenario 3: Data and Data Structure Backup
+
+You have two empty clusters managed from the same account. You create maps on both clusters. This time, you update the default map configuration on Cluster 2 to use a backup count of 2. You ingest 3 GiB of data into each cluster. You run the same query on both clusters and remove the data from both. 
+
+For one hour, data was stored on each cluster.
+
+[cols="2a,2a,a,a"]
+|===
+|Storage Per Cluster|Total Storage|Time|Cost
+
+|*Cluster 1:* 3 GiB (data)
+.2+<.^|12 GiB - 5 GiB (free storage + 1x free backup) = 7 GiB
+.2+<.^|1 hour
+.2+<.^|$0.70
+
+|*Cluster 2:* 3 GiB (data) + 6 GiB (2x backup)
+|
+|
+|
+
+|===
+
+NOTE: As some resources are free of charge, your total resource usage on a cluster dashboard may not match the resources that you are billed for.
 
 == Supported Functionality
 


### PR DESCRIPTION
Split out backups to disk and backups to data structures to make the difference clearer.

Added examples of what resources are charged for.

https://deploy-preview-93--xenodochial-spence-280948.netlify.app/cloud/serverless-cluster.html