### PR TITLE
DOCS-355 Update links and references to CLC

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
     page-url-github-go-sdk: https://github.com/hazelcast/hazelcast-cloud-sdk-go
     page-url-cloud-api: https://cloud.hazelcast.com/v1/api/explorer
     page-code-samples: https://github.com/hazelcast/hazelcast-cloud-code-samples
-    page-cloud-platform-version: 5.1
+    page-cloud-platform-version: 5.2
     page-cloud-console: https://viridian.hazelcast.com/
 nav:
 - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/tools.adoc
+++ b/docs/modules/ROOT/pages/tools.adoc
@@ -27,20 +27,7 @@ See xref:maven-plugin-hazelcast.adoc[].
 == Hazelcast CLC
 [.beta]*Beta*
 
-Hazelcast Command-Line Client (CLC) is a command-line tool for connecting to {hazelcast-cloud} clusters, creating and managing data structures, and monitoring clusters.
+Hazelcast Command-Line Client (CLC) is a command-line tool for connecting to {hazelcast-cloud} Serverless, local, and remote clusters. The Hazelcast CLC also allows you to create and manage data structures, and monitor your clusters.
 
-See the documentation on link:https://github.com/hazelcast/hazelcast-commandline-client[GitHub].
+See xref:clc:ROOT:overview.adoc[the documentation] for installation and configuration details, and a full list of commands.
 
-== Hazelcast {hazelcast-cloud} Go SDK (deprecated)
-
-Hazelcast {hazelcast-cloud} Go SDK is a Go library for creating and managing {hazelcast-cloud} clusters.
-
-The Go SDK is deprecated and no longer maintained.
-
-See the legacy documentation on link:{page-url-github-go-sdk}[GitHub].
-
-== GraphQL API (deprecated)
-
-The GraphQL API is deprecated and no longer maintained.
-
-See the legacy documentation: xref:api-reference.adoc[].

--- a/link-check-playbook.yml
+++ b/link-check-playbook.yml
@@ -39,6 +39,9 @@ content:
   - url: https://github.com/hazelcast/hazelcast-cloud-maven-plugin
     branches: main
     start_path: docs
+  - url: https://github.com/hazelcast/hazelcast-commandline-client
+    branches: [main]
+    start_path: docs
 ui: 
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip


### PR DESCRIPTION
Updated config to include link to CLC and reference on developer tools page.