### PR TITLE
DOCS-403 Heap Memory Warning

### DIFF
--- a/docs/modules/ROOT/pages/data-structures.adoc
+++ b/docs/modules/ROOT/pages/data-structures.adoc
@@ -1,7 +1,9 @@
 = Configuring Data Structures
-:description: You can configure data strutures in the console. Use these references to learn what settings you can configure.
+:description: You can configure data structures in the console. Use these references to learn what settings you can configure.
 
 {description}
+
+WARNING: Serverless clusters have a 1 GB heap memory limit per cluster member. Exceeding this limit can lead to cluster failure. Be aware that the following operations use heap memory: writing, caching, or replicating data to data structures other than IMap and JCache. 
 
 * xref:map-configurations.adoc[]
 * xref:jcache.adoc[]

--- a/docs/modules/ROOT/pages/migrate-to-cloud.adoc
+++ b/docs/modules/ROOT/pages/migrate-to-cloud.adoc
@@ -18,9 +18,16 @@ image::ROOT:serverless-app-server.svg[A Hazelcast client application communicati
 To separate your embedded application into these two parts, see the following checklist:
 
 - [ ] Deploy xref:cluster-side-modules.adoc[cluster-side modules] to Hazelcast {hazelcast-cloud}. If you use classes such as MapStore or an entry processor, or if you store custom objects in Hazelcast, you need to add those classes to the classpath of the cluster by deploying them as cluster-side modules.
+
 - [ ] Copy any data structure configuration over to Hazelcast {hazelcast-cloud}. Data structures are configured in the Hazelcast {hazelcast-cloud} console.
+
++
+WARNING: Serverless clusters have a 1 GB heap memory limit per cluster member. Exceeding this limit can lead to cluster failure. Be aware that the following operations use heap memory: writing, caching, or replicating data to data structures other than IMap and JCache.
+
 - [ ] Remove member configuration from your code. Hazelcast configures the cluster for the best possible performance. All you need to do is configure the client and any data structures.
+
 - [ ] If you use the executor service, make sure that you are using the ‘default’ service in both uploaded executor services and client code. You cannot access named executor services in Hazelcast {hazelcast-cloud}. 
+
 - [ ] Replace any instance of
 `HazelcastInstance
 newHazelcastInstance` with a client. `newHazelcastInstance` creates an instance of a Hazelcast member. Instead, you need to configure a client to xref:connect-to-cluster.adoc[connect to the cluster].

--- a/docs/modules/ROOT/pages/serverless-cluster.adoc
+++ b/docs/modules/ROOT/pages/serverless-cluster.adoc
@@ -70,6 +70,10 @@ Although you can configure some xref:data-structures.adoc[data structures] with 
 
 For example, if you configure a map with five backups, but your cluster has only two members, you will have one effective backup. You need to add enough data to the cluster so that it automatically scales up the number of members and backups to your configured count of five. 
 
+== Limitations of {hazelcast-cloud} Serverless Clusters 
+
+Serverless clusters have a 1 GB heap memory limit per cluster member. Exceeding this limit can lead to cluster failure. Be aware that the following operations use heap memory: writing, caching, or replicating data to xref:data-structures.adoc[data structures] other than IMap and JCache.
+
 == Restrictions on Free {hazelcast-cloud} Serverless Clusters
 
 Development and production clusters are xref:stop-and-resume.adoc#pausing-a-cluster[paused] when both of these conditions are true:


### PR DESCRIPTION
Closes https://hazelcast.atlassian.net/browse/HZC-3956.

Use of heap memory, including uses of non-native data structures added as a limitation and as a warning message where appropriate.