### PR TITLE
DOCS-466 Removed detailed pricing information

### DIFF
--- a/docs/modules/ROOT/pages/dedicated-cluster.adoc
+++ b/docs/modules/ROOT/pages/dedicated-cluster.adoc
@@ -21,64 +21,6 @@ You can design a Hazelcast topology that meets your specific compliance and serv
 
 {hazelcast-cloud} Dedicated clusters are suitable for lightweight or production-critical applications where the workload is generally predictable.
 
-[[dedicated]]
-== Pricing for {hazelcast-cloud} Dedicated Clusters
-
-{hazelcast-cloud} Dedicated clusters are charged for the following:
-
-- *Provisioned memory:* How many resources you asked for when we created the cluster for you.
-- *Data transfer:* The volume of data going into, out of, and within your clusters.
-- *Cluster data storage:* If you requested persistence for your data, this is the cost of storing your cluster data in cloud storage.
-+
-.What is cluster data?
-[%collapsible]
-====
-include::partial$cluster-data.adoc[]
-====
-
-=== Provisioned Memory
-
-Hazelcast charges you a fixed amount, depending on how much memory capacity is reserved for your cluster. If your cluster has 10 GiB capacity but you do not use all that memory, you are still charged for the full 10 GiB because this amount of memory was reserved for your use.
-
-These examples show the cost per month of three clusters that each have a different memory capacity and uptime:
-
-[cols="a,a,a,a"]
-|===
-|Cluster|Memory|Total uptime per month|Cost
-
-|1
-|10 GiB
-|10 hours
-|10 X 10 X $0.10 = $10.00
-
-|2
-|1 GiB
-|100 hours
-|1 X 100 X $0.10 = $10.00
-
-|3
-|3 GiB
-|50 hours
-|3 X 50 X $0.10 = $15.00
-
-|===
-
-In this scenario, the total cost for the month for all three clusters will be: $10.00 + $10.00 + $15.00 = $35.00
-
-{hazelcast-cloud} Dedicated clusters also incur charges for data transfer costs and any backup storage costs.
-
-=== Data Transfer
-
-Data transfer costs account for the volume of data going into, out of, and within your clusters.
-
-Your data transfer charges are aggregated over the month and added to your monthly bill.
-
-=== Cluster Data Storage
-
-If persistence is enabled on your cluster, Hazelcast stores your cluster data in cloud storage, which comes with additional costs.
-
-The cost of cluster data storage depend on the cloud providers cost of storing the data in their object store such as S3 on AWS.
-
 == Supported Functionality
 
 Use this table to learn what is supported in {hazelcast-cloud} Dedicated clusters:

--- a/docs/modules/ROOT/pages/overview.adoc
+++ b/docs/modules/ROOT/pages/overview.adoc
@@ -31,7 +31,7 @@ Hazelcast {hazelcast-cloud} offers two editions: {hazelcast-cloud} Serverless an
 
 |xref:dedicated-cluster.adoc[{hazelcast-cloud} Dedicated] (coming soon)
 |{hazelcast-cloud} Dedicated clusters give you fine-grained control over the hardware and resources available to your cluster. It's your responsibility to scale {hazelcast-cloud} Dedicated clusters when you need more resources.
-|Depends on multiple factors such as the size of your chosen cloud instance.
+|Depends on multiple factors, such as the size of your chosen cloud instance.
 |===
 
 == Getting Started


### PR DESCRIPTION
Pricing section has been removed as requested.

The following line has been left in the overview as this does not contain specific pricing information:

![image](https://user-images.githubusercontent.com/106963942/228799023-762d6061-a232-41e9-bae8-74e20743b22a.png)
