### PR TITLE
Update jdbc-sample-client.adoc

### DIFF
--- a/docs/modules/ROOT/pages/jdbc-sample-client.adoc
+++ b/docs/modules/ROOT/pages/jdbc-sample-client.adoc
@@ -7,7 +7,7 @@
 
 Download the https://github.com/hazelcast/hazelcast-cloud-java-sample-client/blob/master/src/main/java/com/hazelcast/cloud/ClientWithSsl.java[sample client^] from GitHub.
 
-You also need the  _hazelcast-jdbc-enterprise-{version}.jar_ file. You can download this file from https://github.com/hazelcast/hazelcast-jdbc/releases[Releases^].
+You also need the  _hazelcast-jdbc-enterprise-\{version}.jar_ file. You can download this file from https://github.com/hazelcast/hazelcast-jdbc/releases[Releases^].
 
 A JDBC Driver allows a Java application to connect to Hazelcast using the JDBC API. The Hazelcast JDBC Driver is available from https://github.com/hazelcast/hazelcast-jdbc[GitHub^]. 
 


### PR DESCRIPTION
[08:26:48.654] WARN (asciidoctor): skipping reference to missing attribute: version
11:26:48 AM:     file: docs/modules/ROOT/pages/jdbc-sample-client.adoc
11:26:48 AM:     source: https://github.com/hazelcast/cloud-docs (branch: main | start path: docs)