### PR TITLE
Update `CODEOWNERS` to use `documentation` group [DOC-256]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo
-* @hazelcast/documentation
+*   @hazelcast/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo
-*   @Serdaro @rebekah-lawrence @oliverhowell
+* @hazelcast/documentation


### PR DESCRIPTION
Ensure consistency across all doc repos

Fixes: [DOC-256](https://hazelcast.atlassian.net/browse/DOC-256)

[DOC-256]: https://hazelcast.atlassian.net/browse/DOC-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ