### PR TITLE
Remove explicit cURL `POST`

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger build
-      run: curl -X POST -d {} https://api.netlify.com/build_hooks/6050a487dfdfc0aaac6ff8c1
+      run: curl -d {} https://api.netlify.com/build_hooks/6050a487dfdfc0aaac6ff8c1


### PR DESCRIPTION
When executed with `verbose`, cURL logs:
> Note: Unnecessary use of -X or --request, POST is already inferred.

[The `-d`/`--data` flag sends data via `POST`](https://curl.se/docs/manpage.html#-d) so specifying `POST` _as well_ is redundant.